### PR TITLE
Turn into mu plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "mwdelaney/sage-acf-gutenberg-blocks",
+  "type": "wordpress-muplugin",
   "description": "Create Gutenberg blocks from Sage blade templates and ACF fields.",
   "keywords": ["wordpress", "gutenberg", "advanced custom fields"],
   "homepage": "https://github.com/MWDelaney/sage-acf-gutenberg-blocks",
@@ -11,12 +12,14 @@
     },
     {
       "name": "Nico Prat"
-		}
+    },
+    {
+      "name": "Tang Rufus",
+      "email": "tangrufus@gmail.com",
+      "homepage": "https://typist.tech/"
+    }
   ],
   "require": {
     "php": ">=5.3.2"
-  },
-	"autoload": {
-    "files": ["sage-acf-gutenberg-blocks.php"]
   }
 }

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Plugin Name:     mwdelaney/sage-acf-gutenberg-blocks
+ * Plugin URI:      https://www.itineris.co.uk/
+ * Description:     Create Gutenberg blocks from Sage blade templates and ACF fields.
+ * Version:         0.2
+ * Author:          Michael W. Delaney
+ * Author URI:      https://github.com/MWDelaney
+ */
 
 namespace App;
 
@@ -24,11 +32,11 @@ function sage_blocks_callback($block)
  * Create blocks based on templates found in Sage's "views/blocks" directory
  */
 add_action('acf/init', function () {
-  
+
 
     // Set the directory blocks are stored in
     $template_directory = "views/blocks/";
-  
+
     // Set Sage9 friendly path at /theme-directory/resources/views/blocks
     $path = get_stylesheet_directory() . '/' . $template_directory;
 

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -15,7 +15,6 @@ namespace App;
  */
 function sage_blocks_callback($block)
 {
-
   // Set up the slug to be useful
     $slug = str_replace('acf/', '', $block['name']);
 
@@ -32,8 +31,6 @@ function sage_blocks_callback($block)
  * Create blocks based on templates found in Sage's "views/blocks" directory
  */
 add_action('acf/init', function () {
-
-
     // Set the directory blocks are stored in
     $template_directory = "views/blocks/";
 


### PR DESCRIPTION
[Autoloading `sage-acf-gutenberg-blocks.php`](https://github.com/MWDelaney/sage-acf-gutenberg-blocks/blob/6eac68833bb12477b40086d831421c589b4cfc27/composer.json#L20) triggers [`add_action`](https://github.com/MWDelaney/sage-acf-gutenberg-blocks/blob/6eac68833bb12477b40086d831421c589b4cfc27/sage-acf-gutenberg-blocks.php#L26) whenever composer vendor is loaded.

It breaks when using with wp-cli.

Steps:
1. Setup a normal bedrock + Sage site
1. $ cd /path/to/sage
1. $ composer require "mwdelaney/sage-acf-gutenberg-blocks"
1. $ wp db reset --yes --skip-packages --skip-themes --skip-plugins
1. Boom!
```
wp db reset --yes --skip-packages --skip-themes --skip-plugins


Fatal error: Uncaught Error: Call to undefined function add_action() in /home/circleci/project/vendor/mwdelaney/sage-acf-gutenberg-blocks/sage-acf-gutenberg-blocks.php on line 26

Error: Call to undefined function add_action() in /home/circleci/project/vendor/mwdelaney/sage-acf-gutenberg-blocks/sage-acf-gutenberg-blocks.php on line 26
```

It breaks on other wp cli commands as well.

