### PR TITLE
Feature: Enable Bud bundle support / Fix EnqueueStyles & EnqueueScripts

### DIFF
--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -233,8 +233,6 @@ function removeBladeExtension($filename)
  */
 function checkAssetPath(&$path, $block)
 {
-    $usesBud = true;
-
     if (isSage10() && function_exists('\Roots\bundle')) { // Bud
         try {
             $bundle = \Roots\bundle($path);
@@ -254,13 +252,11 @@ function checkAssetPath(&$path, $block)
             $path = ''; // Reset path
             return;
         } catch (\Exception $e) {
-            $usesBud = false;
+            //
         }
-    } else {
-        $usesBud = false;
     }
 
-    if (!$usesBud && preg_match("/^(styles|scripts)/", $path)) {
+    if (preg_match("/^(styles|scripts)/", $path)) {
         if (isSage10()) {
             $path = \Roots\asset($path)->uri(); // Laravel Mix (Pre-Bud Sage)
         } else {

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -83,13 +83,14 @@ add_action('acf/init', function () {
                     $sage_error(__('This block needs a category: ' . $dir . '/' . $template->getFilename(), 'sage'), __('Block category missing', 'sage'));
                 }
 
-                // Checks if dist contains this asset, then enqueues the dist version.
-                if (!empty($file_headers['enqueue_style'])) {
-                    checkAssetPath($file_headers['enqueue_style']);
+                // Checks if it can find the bundle name to include with Bud.
+                // Checks if public contains this asset, then enqueues the public version. (Pre-Bud Sage)
+                if ($file_headers['enqueue_style']) {
+                    checkAssetPath($file_headers['enqueue_style'], $slug);
                 }
 
-                if (!empty($file_headers['enqueue_script'])) {
-                    checkAssetPath($file_headers['enqueue_script']);
+                if ($file_headers['enqueue_script']) {
+                    checkAssetPath($file_headers['enqueue_script'], $slug);
                 }
 
                 // Set up block data for registration
@@ -226,13 +227,45 @@ function removeBladeExtension($filename)
  * Checks asset path for specified asset.
  *
  * @param string &$path
+ * @param string $block
  *
  * @return void
  */
-function checkAssetPath(&$path)
+function checkAssetPath(&$path, $block)
 {
-    if (preg_match("/^(styles|scripts)/", $path)) {
-        $path = isSage10() ? \Roots\asset($path)->uri() : \App\asset_path($path);
+    $usesBud = true;
+
+    if (isSage10() && function_exists('\Roots\bundle')) { // Bud
+        try {
+            $bundle = \Roots\bundle($path);
+
+            add_action('wp_enqueue_scripts', function () use ($block, $bundle) {
+                if (has_block("acf/$block")) {
+                    $bundle->enqueue();
+                }
+            }, 50);
+
+            add_action('enqueue_block_editor_assets', function () use ($block, $bundle) {
+                if (has_block("acf/$block")) {
+                    $bundle->enqueue();
+                }
+            }, 50);
+
+            $path = ''; // Reset path
+            return;
+        } catch (\Exception $e) {
+            $usesBud = false;
+        }
+    } else {
+        $usesBud = false;
+    }
+
+    if (!$usesBud && preg_match("/^(styles|scripts)/", $path)) {
+        if (isSage10()) {
+            $path = \Roots\asset($path)->uri(); // Laravel Mix (Pre-Bud Sage)
+        } else {
+            $path = \App\asset_path($path);
+        }
     }
 }
 


### PR DESCRIPTION
The current Sage theme comes with Bud by default now, instead of Laravel Mix. Bud uses bundle names to enqueue assets and not paths like before. I made the adjustments so that we can now use the Bud bundles as a value of EnqueueStyles and EnqueueScripts. It would look like this:

```
EnqueueStyles: nameofbundle
EnqueueScripts: nameofanotherbundle
```
If the bundle is not found, it will still try to enqueue a path to file in public like before.

I made sure not to break backwards compatibility, so Sage <10 users and Laravel Mix users on older versions will not get in trouble with this update.